### PR TITLE
Feature/meta graph: counts rm

### DIFF
--- a/aced_submission/meta.py
+++ b/aced_submission/meta.py
@@ -119,7 +119,7 @@ def _node_counts(config_path, output_format):
     cur = conn.cursor()
     cur.execute(sql)
     counts = cur.fetchall()
-    counts = [{'hierarchy_rank': _[0], 'table': _[1], 'node': _[2], 'count': _[3]} for _ in counts]
+    counts = [{'hierarchy_rank': _[0], 'table': _[1], 'node': _[2], 'project_id': _[3], 'count': _[4]} for _ in counts]
     if output_format == 'yaml':
         yaml.dump(counts, sys.stdout, default_flow_style=False)
     else:

--- a/aced_submission/meta.py
+++ b/aced_submission/meta.py
@@ -162,9 +162,9 @@ def _graph_rm(config_path, project_id, output_format):
             for rank, _ in reverse_dependency_order:
                 if _.startswith('_'):
                     continue
-                curs.execute(f"delete from 'node_{_.lower()}' where _props->>'project_id' = ?", (project_id,))
+                curs.execute(f"delete from node_{_.lower()} where _props->>'project_id' = %s;", (project_id,))
                 results.append({'table': f'node_{_.lower()}', 'project_id': project_id, 'count': curs.rowcount})
-            curs.execute(f"delete from 'node_project' where _props->>'code' = ?", (project,))
+            curs.execute(f"delete from node_project where _props->>'code' = %s;", (project,))
             results.append({'table': f'node_project', 'project_id': project, 'count': curs.rowcount})
 
     if output_format == 'yaml':

--- a/aced_submission/meta_flat_load.py
+++ b/aced_submission/meta_flat_load.py
@@ -664,5 +664,6 @@ def _delete(project_id, index):
     }
     print(index, elastic.delete_by_query(index=index, body=query))
 
+
 if __name__ == '__main__':
     cli()

--- a/aced_submission/meta_flat_load.py
+++ b/aced_submission/meta_flat_load.py
@@ -611,5 +611,58 @@ def chunk(arr_range, arr_size):
     return iter(lambda: tuple(islice(arr_range, arr_size)), ())
 
 
+@cli.command('counts')
+@click.option('--project_id', required=True,
+              default=None,
+              show_default=True,
+              help='program-project'
+              )
+def _counts(project_id):
+    """Count the number of patients, observations, and files."""
+    elastic = Elasticsearch([DEFAULT_ELASTIC], request_timeout=120)
+    program, project = project_id.split('-')
+    assert program, "program is required"
+    assert project, "project is required"
+    query = {
+        "query": {
+            "match": {
+                "auth_resource_path": f"/programs/{program}/projects/{project}"
+            }
+        }
+    }
+    for index in ['patient', 'observation', 'file']:
+        # index = f"{ES_INDEX_PREFIX}_{index}_0"
+        print(index, elastic.count(index=index, body=query)['count'])
+
+
+@cli.command('rm')
+@click.option('--project_id', required=True,
+              default=None,
+              show_default=True,
+              help='program-project'
+              )
+@click.option('--index', required=True,
+              default=None,
+              show_default=True,
+              help='one of patient, observation, file'
+              )
+
+def _delete(project_id, index):
+    """Delete items from elastic index for project_id."""
+    elastic = Elasticsearch([DEFAULT_ELASTIC], request_timeout=120)
+    assert project_id, "project_id is required"
+    program, project = project_id.split('-')
+    assert program, "program is required"
+    assert project, "project is required"
+    assert index, "index is required"
+    query = {
+        "query": {
+            "match": {
+                "auth_resource_path": f"/programs/{program}/projects/{project}"
+            }
+        }
+    }
+    print(index, elastic.delete_by_query(index=index, body=query))
+
 if __name__ == '__main__':
     cli()

--- a/aced_submission/meta_flat_load.py
+++ b/aced_submission/meta_flat_load.py
@@ -662,7 +662,8 @@ def _delete(project_id, index):
             }
         }
     }
-    print(index, elastic.delete_by_query(index=index, body=query))
+    print("deleting, waiting up to 5 min. for response")
+    print(index, elastic.delete_by_query(index=index, body=query, timeout='5m'))
 
 
 if __name__ == '__main__':

--- a/aced_submission/meta_graph_load.py
+++ b/aced_submission/meta_graph_load.py
@@ -132,7 +132,7 @@ def load_edges(files, connection, dependency_order, mapping, project_node_id):
                         if d_['name'] in ['ResearchStudy', 'research_study']:
                             # link the ResearchStudy to the gen3 project
                             relations.append({"dst_id": project_node_id, "dst_name": "Project", "label": "project"})
-                            logger.info(f"adding project relation from project({project_node_id}) to research_study{d_['id']} {d_['code']}")
+                            logger.info(f"adding project relation from project({project_node_id}) to research_study{d_['id']}")
 
                         if len(relations) == 0:
                             continue

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
 
     # Versions should comply with PEP 440:
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.3',  # Required
+    version='0.0.4',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
 
     # Versions should comply with PEP 440:
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.2',  # Required
+    version='0.0.3',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:


### PR DESCRIPTION
This PR adds commands to meta flat.
Note: the `rm` command removes all project content from the graph


* query sheepdog `meta graph counts`

```
 aced_submission meta graph counts --format json | jq -rc '.[] | select(.project_id == "aced-Alzheimers") | [.table, .count]'
["node_researchstudy",1]
["node_patient",287]
["node_researchsubject",287]
["node_specimen",75]
["node_observation",192086]
["node_condition",4311]
["node_medicationadministration",199]
["node_documentreference",730]
["node_task",75]
```

* delete project contents from sheepdog `meta graph rm`
```
# aced_submission meta graph rm --project_id aced-Alzheimers
- count: 0
  project_id: aced-Alzheimers
  table: node_familymemberhistory
- count: 75
  project_id: aced-Alzheimers
  table: node_task
- count: 730
  project_id: aced-Alzheimers
  table: node_documentreference
- count: 199
  project_id: aced-Alzheimers
  table: node_medicationadministration
- count: 0
  project_id: aced-Alzheimers
  table: node_medication
- count: 4311
  project_id: aced-Alzheimers
  table: node_condition
- count: 192086
  project_id: aced-Alzheimers
  table: node_observation
- count: 75
  project_id: aced-Alzheimers
  table: node_specimen
- count: 0
  project_id: aced-Alzheimers
  table: node_substance
- count: 287
  project_id: aced-Alzheimers
  table: node_researchsubject
- count: 287
  project_id: aced-Alzheimers
  table: node_patient
- count: 1
  project_id: aced-Alzheimers
  table: node_researchstudy
- count: 1
  project_id: Alzheimers
  table: node_project
```

* re-query
```
aced_submission meta graph counts --format json | jq -rc '.[] | select(.project_id == "aced-Alzheimers") | [.table, .count]'
>>> nothing returned
```
* project no longer exists, but is still in arborist resources (expected)

```
 gen3_util projects ls
...
  /programs/aced/projects/Alzheimers:
    exists: false

```

