### PR TITLE
fix/export-all-fhir

### DIFF
--- a/aced_submission/fhir_store.py
+++ b/aced_submission/fhir_store.py
@@ -4,6 +4,7 @@ import pathlib
 import sys
 
 import click
+import elasticsearch
 import yaml
 from elasticsearch import Elasticsearch
 
@@ -76,8 +77,11 @@ def fhir_get(project_id, path, elastic_url) -> list[str]:
 
     auth_resource_path = f"/programs/{program}/projects/{project}"
 
-    res = elastic.search(index=index, body={"query": {"match": {"auth_resource_path": auth_resource_path}}})
-    for _ in res['hits']['hits']:
+    for _ in elasticsearch.helpers.scan(
+        client=elastic,
+        query={"query": {"match": {"auth_resource_path": auth_resource_path}}},
+        index=index
+    ):
         resource_type = _['_source']['resourceType']
         _file = _emitter(resource_type)
         del _['_source']['auth_resource_path']

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
 
     # Versions should comply with PEP 440:
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.9rc6',  # Required
+    version='0.0.9rc7',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:


### PR DESCRIPTION
This PR:
* fixes the export `get` command by scrolling over all fhir data
* bumps release to 0.0.9rc7