### PR TITLE
Feature/bulk query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pip-wheel-metadata/
 share/python-wheels/
 *.egg-info/
 .installed.cfg
+.DS_Store
 *.egg
 MANIFEST
 

--- a/aced_submission/grip_load.py
+++ b/aced_submission/grip_load.py
@@ -1,18 +1,17 @@
 import os
 import orjson
 import requests
-import orjson
 from typing import List, Generator
 
 
-GRIP_SERVICE = "local-grip:8201"
 NGINX_PATH = "graphql"
 PROTOBUF_PATH = "v1/graph"
 
 
-def bulk_load(graph_name: str, project_id: str, directory_path: str, output: dict, access_token: str) -> List[dict]:
+def bulk_load(grip_service: str, graph_name: str, project_id: str, directory_path: str, output: dict, access_token: str) -> List[dict]:
     """Loads a directory of .ndjson or .gz files to grip.
         Args:
+                grip_service: The name of the k8s service that refers to the internal cluster-ip for the running grip deployment
                 graph_name: The name of the graph
                 project_id: the Gen3 program-project to be used
                 directory_path: the file path to the directory that contains the FHIR files
@@ -22,17 +21,17 @@ def bulk_load(graph_name: str, project_id: str, directory_path: str, output: dic
         TODO: implement FHIR schema in grip
                     so that edges that don't validate in graph are rejected
     """
-    response_json= []
+    response_json = []
 
     # List graphs and check to see if graph name is amoung the graphs listed
-    exists = graph_exists(graph_name, output, access_token)
+    exists = graph_exists(grip_service, graph_name, output, access_token)
     assert exists, output["logs"].append(f"ERROR: graph {graph_name} not found in grip")
 
     output["logs"].append(f"loading files into {graph_name} from {directory_path}")
 
     assert os.path.isdir(directory_path), output["logs"].append(f"directory path {directory_path} is not a directory")
     importable_files = [f for f in os.listdir(directory_path) if any([f.endswith(".json"), f.endswith(".gz"), f.endswith(".ndjson")])]
-    assert len(importable_files) > 0, output["logs"].append(f"No .json, .gz or .ndjson files have been uploaded")
+    assert len(importable_files) > 0, output["logs"].append("No .json, .gz or .ndjson files have been uploaded")
 
     output["logs"].append(f"files in {directory_path}: {str(os.listdir(directory_path))}")
     output["logs"].append(f"importable files found: {str(importable_files)}")
@@ -44,7 +43,7 @@ def bulk_load(graph_name: str, project_id: str, directory_path: str, output: dic
         with open(file_path, 'rb') as file_io:
             files = {'file': (file_path, file_io)}
             response = requests.post(
-                f"http://{GRIP_SERVICE}/{NGINX_PATH}/{graph_name}/bulk-load/{project_id}",
+                f"http://{grip_service}:8201/{NGINX_PATH}/{graph_name}/bulk-load/{project_id}",
                 data={"types": graph_component},
                 headers={"Authorization": f"bearer {access_token}"},
                 files=files
@@ -57,7 +56,7 @@ def bulk_load(graph_name: str, project_id: str, directory_path: str, output: dic
     return response_json
 
 
-def bulk_delete(graph_name: str, vertices: List[str], project_id: str,  edges: List[str], output: dict, access_token: str) -> dict:
+def bulk_delete(grip_service: str, graph_name: str, vertices: List[str], project_id: str,  edges: List[str], output: dict, access_token: str) -> dict:
     """Deletes graph elements from a grip graph.
         Args:
             graph_name: The name of the graph
@@ -69,7 +68,7 @@ def bulk_delete(graph_name: str, vertices: List[str], project_id: str,  edges: L
             "vertices": vertices,
             "edges": edges
             }
-    response = requests.delete(f"http://{GRIP_SERVICE}/{NGINX_PATH}/{graph_name}/bulk-delete/{project_id}",
+    response = requests.delete(f"http://{grip_service}:8201/{NGINX_PATH}/{graph_name}/bulk-delete/{project_id}",
                                data=orjson.dumps(data),
                                headers={"Authorization": f"bearer {access_token}"}
                                )
@@ -80,9 +79,9 @@ def bulk_delete(graph_name: str, vertices: List[str], project_id: str,  edges: L
     return json_data
 
 
-def delete_edge(graph_name: str, edge_id: str, project_id: str, output: dict, access_token: str) -> dict:
+def delete_edge(grip_service: str, graph_name: str, edge_id: str, project_id: str, output: dict, access_token: str) -> dict:
     """Deletes one edge from the specified graph"""
-    response = requests.delete(f"http://{GRIP_SERVICE}/{NGINX_PATH}/{graph_name}/del-edge/{project_id}/{edge_id}",
+    response = requests.delete(f"http://{grip_service}:8201/{NGINX_PATH}/{graph_name}/del-edge/{project_id}/{edge_id}",
                                headers={"Authorization": f"bearer {access_token}"}
                                )
 
@@ -92,9 +91,9 @@ def delete_edge(graph_name: str, edge_id: str, project_id: str, output: dict, ac
     return json_data
 
 
-def delete_vertex(graph_name: str, vertex_id: str, project_id: str, output: dict, access_token: str) -> dict:
+def delete_vertex(grip_service: str, graph_name: str, vertex_id: str, project_id: str, output: dict, access_token: str) -> dict:
     """Deletes one vertex from the specified graph"""
-    response = requests.delete(f"http://{GRIP_SERVICE}/{NGINX_PATH}/{graph_name}/del-vertex/{project_id}/{vertex_id}",
+    response = requests.delete(f"http://{grip_service}:8201/{NGINX_PATH}/{graph_name}/del-vertex/{project_id}/{vertex_id}",
                                headers={"Authorization": f"bearer {access_token}"}
                                )
 
@@ -104,7 +103,7 @@ def delete_vertex(graph_name: str, vertex_id: str, project_id: str, output: dict
     return json_data
 
 
-def add_vertex(graph_name: str, vertex: dict, project_id: str, output: dict, access_token: str) -> dict:
+def add_vertex(grip_service: str, graph_name: str, vertex: dict, project_id: str, output: dict, access_token: str) -> dict:
     """Adds one vertex to the specified graph
         required vertex format:
             {
@@ -113,7 +112,7 @@ def add_vertex(graph_name: str, vertex: dict, project_id: str, output: dict, acc
                 "data": dict, vertex properties.
             }
     """
-    response = requests.post(f"http://{GRIP_SERVICE}/{NGINX_PATH}/{graph_name}/add-vertex/{project_id}/{vertex['gid']}",
+    response = requests.post(f"http://{grip_service}:8201/{NGINX_PATH}/{graph_name}/add-vertex/{project_id}/{vertex['gid']}",
                              headers={"Authorization": f"bearer {access_token}"},
                              json=vertex
                              )
@@ -124,7 +123,7 @@ def add_vertex(graph_name: str, vertex: dict, project_id: str, output: dict, acc
     return json_data
 
 
-def add_edge(graph_name: str, edge: dict, project_id: str, output: dict, access_token: str) -> dict:
+def add_edge(grip_service: str, graph_name: str, edge: dict, project_id: str, output: dict, access_token: str) -> dict:
     """Adds one edge to the specified graph
         required edge format:
             {
@@ -135,7 +134,7 @@ def add_edge(graph_name: str, edge: dict, project_id: str, output: dict, access_
                 "data": dict, optional edge properties.
             }
     """
-    response = requests.post(f"http://{GRIP_SERVICE}/{NGINX_PATH}/{graph_name}/add-edge/{project_id}/{edge['gid']}",
+    response = requests.post(f"http://{grip_service}:8201/{NGINX_PATH}/{graph_name}/add-edge/{project_id}/{edge['gid']}",
                              headers={"Authorization": f"bearer {access_token}"},
                              json=edge
                              )
@@ -146,9 +145,9 @@ def add_edge(graph_name: str, edge: dict, project_id: str, output: dict, access_
     return json_data
 
 
-def list_graphs(output: dict, access_token: str) -> dict:
+def list_graphs(grip_service: str, output: dict, access_token: str) -> dict:
     """Returns a list of all graph names in grip"""
-    response = requests.get(f"http://{GRIP_SERVICE}/{NGINX_PATH}/list-graphs",
+    response = requests.get(f"http://{grip_service}:8201/{NGINX_PATH}/list-graphs",
                             headers={"Authorization": f"bearer {access_token}"}
                             )
 
@@ -159,7 +158,7 @@ def list_graphs(output: dict, access_token: str) -> dict:
     return json_data
 
 
-def add_schema(graph_name: str, schema_path: str, project_id: str, output: dict, access_token: str) -> dict:
+def add_schema(grip_service: str, graph_name: str, schema_path: str, project_id: str, output: dict, access_token: str) -> dict:
     """Adds a schema to a graph in grip. NOTE: currently the schema that is attached to the graph
     is whatever graph is specified with the '"graph": "ESCA"' at the top of the schema file,
     not the graph_name that is specified"""
@@ -168,7 +167,7 @@ def add_schema(graph_name: str, schema_path: str, project_id: str, output: dict,
     with open(schema_path, 'rb') as file_io:
         files = {'file': (schema_path, file_io)}
         response = requests.post(
-            f"http://{GRIP_SERVICE}/{NGINX_PATH}/{graph_name}/add-schema/{project_id}",
+            f"http://{grip_service}:8201/{NGINX_PATH}/{graph_name}/add-schema/{project_id}",
             headers={"Authorization": f"bearer {access_token}"},
             files=files
         )
@@ -178,25 +177,25 @@ def add_schema(graph_name: str, schema_path: str, project_id: str, output: dict,
     return json_data
 
 
-def add_graph(graph_name: str, project_id: str, output: dict, access_token: str) -> dict:
+def add_graph(grip_service: str, graph_name: str, project_id: str, output: dict, access_token: str) -> dict:
     """Creates a new graph"""
 
-    response = requests.post(f"http://{GRIP_SERVICE}/{NGINX_PATH}/{graph_name}/add-graph/{project_id}",
-                                headers={"Authorization": f"bearer {access_token}"})
+    response = requests.post(f"http://{grip_service}:8201/{NGINX_PATH}/{graph_name}/add-graph/{project_id}",
+                             headers={"Authorization": f"bearer {access_token}"})
 
     json_data = response.json()
     output["logs"].append(f"add-graph response: {json_data}")
     return json_data
 
 
-def drop_graph(graph_name: str, project_id: str, output: dict, access_token: str) -> dict:
+def drop_graph(grip_service: str, graph_name: str, project_id: str, output: dict, access_token: str) -> dict:
     """Deletes a graph and all of its data"""
 
-    exists = graph_exists(graph_name, output, access_token)
+    exists = graph_exists(grip_service, graph_name, output, access_token)
     # Not going to get a grip error if you attempt to delete something that doesn't exist it grip,
     # But it might be good to still have an assert statement here to catch the fact that the graph doesn't exist
     assert exists, output["logs"].append(f"Graph {graph_name} does not exist in grip")
-    response = requests.delete(f"http://{GRIP_SERVICE}/{NGINX_PATH}/{graph_name}/del-graph/{project_id}",
+    response = requests.delete(f"http://{grip_service}:8201/{NGINX_PATH}/{graph_name}/del-graph/{project_id}",
                                headers={"Authorization": f"bearer {access_token}"})
 
     json_data = response.json()
@@ -204,16 +203,16 @@ def drop_graph(graph_name: str, project_id: str, output: dict, access_token: str
     return json_data
 
 
-def graph_exists(graph_name: str, output: dict, access_token: str) -> bool:
+def graph_exists(grip_service: str, graph_name: str, output: dict, access_token: str) -> bool:
     """Check to see if the provided graph name exists in grip"""
-    existing_graphs = list_graphs(output, access_token)["data"]["graphs"]
+    existing_graphs = list_graphs(grip_service, output, access_token)["data"]["graphs"]
     return graph_name in existing_graphs
 
 
-def delete_project(graph_name: str, project_id: str, output: dict, access_token: str) -> dict:
+def delete_project(grip_service: str, graph_name: str, project_id: str, output: dict, access_token: str) -> dict:
     """Delete a gen3 project entirely from a grip graph"""
     response = requests.delete(
-            f"http://{GRIP_SERVICE}/{NGINX_PATH}/{graph_name}/proj-delete/{project_id}",
+            f"http://{grip_service}:8201/{NGINX_PATH}/{graph_name}/proj-delete/{project_id}",
             headers={"Authorization": f"bearer {access_token}"},
             )
 
@@ -222,12 +221,13 @@ def delete_project(graph_name: str, project_id: str, output: dict, access_token:
     return json_data
 
 
-def get_project_data(graph_name: str, project_id: str, output:dict, access_token: str)-> Generator[dict, None, None]:
+def get_project_data(grip_service: str, graph_name: str, project_id: str, output: dict, access_token: str) -> Generator[dict, None, None]:
     """Retrieves all of the data for a given project id on a given graph"""
     response = requests.get(
-        f"http://{GRIP_SERVICE}/{NGINX_PATH}/{graph_name}/get-vertices/{project_id}",
-        headers={"Authorization":f"bearer {access_token}"}
+        f"http://{grip_service}:8201/{NGINX_PATH}/{graph_name}/get-vertices/{project_id}",
+        headers={"Authorization": f"bearer {access_token}"}
     )
+
     def stream_res(response):
         for result in response.iter_lines(chunk_size=None):
             try:
@@ -242,7 +242,9 @@ def get_project_data(graph_name: str, project_id: str, output:dict, access_token
 
 """WARNING The functions below use the GRIP protobuf API directly and bipass Auth checks
             and should not be used for Gen3 Purposes."""
-def proto_stream_query(graph_name: str, query: dict) -> Generator[dict, None, None]:
+
+
+def proto_stream_query(grip_service: str, graph_name: str, query: dict) -> Generator[dict, None, None]:
     """Get all records for an vertex type.
         This function uses the internal protobuf API instead of the plugin API
             For example query dict for getting all of the Observation vertices:
@@ -255,7 +257,7 @@ def proto_stream_query(graph_name: str, query: dict) -> Generator[dict, None, No
     """
 
     response = requests.post(
-        f"http://{GRIP_SERVICE}/{PROTOBUF_PATH}/{graph_name}/query",
+        f"http://{grip_service}:8201/{PROTOBUF_PATH}/{graph_name}/query",
         data=orjson.dumps(query),
     )
 
@@ -271,7 +273,7 @@ def proto_stream_query(graph_name: str, query: dict) -> Generator[dict, None, No
     return stream_protobuf_res(response)
 
 
-def list_labels(graph_name: str) -> dict:
+def list_labels(grip_service: str, graph_name: str) -> dict:
     """Get all of the edge and vertex labels for a given graph.
         Label names are based off of FHIR vertex and edge names
         Example response:
@@ -288,6 +290,6 @@ def list_labels(graph_name: str) -> dict:
             }
     """
     response = requests.get(
-        f"http://{GRIP_SERVICE}/{PROTOBUF_PATH}/{graph_name}/label"
+        f"http://{grip_service}:8201/{PROTOBUF_PATH}/{graph_name}/label"
     )
     return response.json()

--- a/aced_submission/grip_load.py
+++ b/aced_submission/grip_load.py
@@ -225,7 +225,7 @@ def delete_project(graph_name: str, project_id: str, output: dict, access_token:
 def proto_stream_query(graph_name: str, query: dict) -> Generator[dict, None, None]:
     """Get all records for an vertex type.
         This function uses the internal protobuf API instead of the plugin API
-            Ex query dict for getting all of the Observation vertices:
+            For example query dict for getting all of the Observation vertices:
                 data = {
                         "query": [
                             {"v": []},
@@ -249,3 +249,25 @@ def proto_stream_query(graph_name: str, query: dict) -> Generator[dict, None, No
             yield result_dict["vertex"]["data"]
 
     return stream_protobuf_res(response)
+
+
+def list_labels(graph_name: str) -> dict:
+    """Get all of the edge and vertex labels for a given graph.
+        Label names are based off of FHIR vertex and edge names
+        Example response:
+            {'vertexLabels':
+                  ['BodyStructure', 'Condition', 'DocumentReference', 'Observation',
+                   'Organization', 'Patient', 'ResearchStudy', 'ResearchSubject', 'Specimen'],
+             'edgeLabels':
+                  ['body_structure', 'condition', 'document_reference',
+                   'focus_DocumentReference', 'focus_Specimen', 'focus_observation',
+                   'parent', 'parent_specimen', 'partOf', 'partOf_research_study',
+                   'patient', 'research_subject', 'specimen', 'specimen_Specimen',
+                   'specimen_observation', 'study', 'subject_Patient',
+                   'subject_Specimen', 'subject_observation']
+            }
+    """
+    response = requests.get(
+        f"http://{GRIP_SERVICE}/{PROTOBUF_PATH}/{graph_name}/label"
+    )
+    return response.json()

--- a/aced_submission/meta_discovery_load.py
+++ b/aced_submission/meta_discovery_load.py
@@ -122,7 +122,6 @@ def discovery_load(project_id: str, _subjects_count: int, description: str, loca
     except requests.exceptions.HTTPError as e:
         print(str(e))
 
-
     """TODO old code for loading discovery page. Repurpose if we implement discovery page
     in FF
 

--- a/aced_submission/meta_flat_load.py
+++ b/aced_submission/meta_flat_load.py
@@ -16,7 +16,6 @@ from typing import Dict, Iterator, Any, Generator, List
 
 import click
 from dateutil.parser import parse
-from dateutil import tz
 from gen3_tracker.meta.dataframer import LocalFHIRDatabase
 import orjson
 from opensearchpy import OpenSearch as Elasticsearch
@@ -72,7 +71,7 @@ def generate_elasticsearch_mapping(df: List[Dict]) -> Dict[str, Any]:
 
     def is_integer_dtype(value: Any) -> bool:
         return isinstance(value, int) and value.bit_length() <= 32 and not isinstance(value, bool)
-    
+
     def is_long_dtype(value: Any) -> bool:
         return isinstance(row[column], int) and row[column].bit_length() > 32
 
@@ -126,7 +125,7 @@ def generate_elasticsearch_mapping(df: List[Dict]) -> Dict[str, Any]:
                     mapping["mappings"]["properties"][column] = {"type": "keyword"}
             elif isinstance(row[column], str):
                 mapping["mappings"]["properties"][column] = {"type": "keyword"}
-    
+
     return mapping
 
 
@@ -218,9 +217,9 @@ def write_bulk_http(elastic, index, limit, doc_type, generator) -> None:
 
     logger.info(f'Writing bulk to {index} limit {limit}.')
     _ = bulk(client=elastic,
-                       actions=(d for d in _bulker(generator)),
-                       request_timeout=120,
-                       max_retries=5)
+             actions=(d for d in _bulker(generator)),
+             request_timeout=120,
+             max_retries=5)
 
     return
 
@@ -232,6 +231,7 @@ def resource_generator(project_id, generator) -> Iterator[Dict]:
         resource['project_id'] = project_id
         resource["auth_resource_path"] = f"/programs/{program}/projects/{project}"
         yield resource
+
 
 @lru_cache(maxsize=1024 * 10)
 def fetch_denormalized_patient(connection, patient_id):
@@ -539,7 +539,7 @@ def load_flat(project_id: str, index: str, generator: Generator[dict, None, None
                             generator=loading_generator)
 
     load_index(elastic=elastic, output_path=output_path, es_index=f"{ES_INDEX_PREFIX}_{index}_0",
-                alias=index, doc_type=index, limit=limit)
+               alias=index, doc_type=index, limit=limit)
 
 
 def chunk(arr_range, arr_size):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
 
     # Versions should comply with PEP 440:
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.9rc35',  # Required
+    version='0.0.9rc36',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
 
     # Versions should comply with PEP 440:
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.9rc36',  # Required
+    version='0.0.9rc37',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
 
     # Versions should comply with PEP 440:
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.9rc33',  # Required
+    version='0.0.9rc34',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
 
     # Versions should comply with PEP 440:
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.9rc34',  # Required
+    version='0.0.9rc35',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:


### PR DESCRIPTION
Adds bulk query helper function that queries grip directly and returns generator that is compatible with existing g3t tooling

The purpose of fetching data directly from GRIP instead of loading the Data files as they are submitted is so that a new data frame in elastic can be reloaded every time new additions are made, and the central source of truth, GRIP can be used as medium for fetching FHIR data to be data framed 